### PR TITLE
Improved mergeability of Pillar data (rsync shell scripts) 

### DIFF
--- a/backupninja/defaults.yaml
+++ b/backupninja/defaults.yaml
@@ -43,7 +43,7 @@ backupninja:
         from: local
         include:
           - /etc
-          - /var/backups/*/
+          - /var/backups/
       dest:
         dest: remote
         user: remoteuser

--- a/backupninja/files/generic.sh.jinja
+++ b/backupninja/files/generic.sh.jinja
@@ -14,8 +14,17 @@ truncate -s0 "{{ log }}"
 {{ rsync.get('command', 'rsync') }} \
   --rsh 'ssh -p {{ rsync.get('port', 22) }}' \
   --log-file {{ log }} \
+{%-   if rsync.args is string %}
   {{ rsync.args }} \
-  {{ rsync.from }} {{ rsync.to }} || fatal "rsync failed"
+{%-   else %}
+  {{ rsync.args | join(' ') }} \
+{%-   endif %}
+{%-   if rsync.from is string %}
+  {{ rsync.from }} \
+{%-   else %}
+  {{ rsync.from | join(' ') }} \
+{%-   endif %}
+  {{ rsync.to }} || fatal "rsync failed"
 {%- endif %}
 
 {%- if 'stop_services' in config %}

--- a/pillar.example
+++ b/pillar.example
@@ -36,9 +36,18 @@ backupninja:
         port: 22 # default
         log: /var/log/backup/custom-rsync.log  # default
         truncate_log: False  # default. (Set this to True when no log rotation is present.)
-        from: /etc/
+        from: /etc/ /var/backups/
+        # alternate form for 'from':
+        from:
+          - /etc/
+          - /var/backups/
         to: user@host:backup
         args: --recursive --times --delete
+        # alternate form for 'args':
+        args:
+          - '--recursive'
+          - '--times'
+          - '--delete'
     13-custom.sh:
       template: salt://backupninja/files/my_custom_template.sh.jinja
       var1: a

--- a/pillar.example
+++ b/pillar.example
@@ -14,7 +14,7 @@ backupninja:
           from: local  # default
           include:  # default
             - /etc
-            - /var/backups/*/
+            - /var/backups/
           exclude:
             - exclude_folder1
             - exclude_folder2


### PR DESCRIPTION
- Ease the use of [pillar.stack](https://docs.saltstack.com/en/latest/ref/pillar/all/salt.pillar.stack.html) by allowing lists instead of arrays in `rsync.args` and `rsync.from`.
- Fix default values.

Tested on 

- Ubuntu 18.04.1
- Debian 9.5